### PR TITLE
feat: Android APK build and GitHub Release workflow (Etapa 3)

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,61 @@
+name: Android - Build e Release APK
+
+on:
+  pull_request:
+    branches:
+      - release
+  push:
+    branches:
+      - release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout do código
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Instalar dependências
+        run: npm ci
+
+      - name: Criar arquivo .env com chave da API do TMDB
+        run: echo "EXPO_PUBLIC_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}" > .env
+
+      - name: Gerar projeto Android com Expo Prebuild
+        run: npx expo prebuild --platform android --no-install
+
+      - name: Permissão de execução no gradlew
+        run: chmod +x android/gradlew
+
+      - name: Build APK Release
+        working-directory: android
+        run: ./gradlew assembleRelease
+
+      - name: Upload do APK como artefato
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-v${{ github.run_number }}
+          path: android/app/build/outputs/apk/release/app-release.apk
+
+      - name: Criar GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.run_number }}
+          name: Release v${{ github.run_number }}
+          files: android/app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
## Etapa 3 – Build Nativo e Release de APK

Fixes #4

## O que foi feito

- Criação do workflow `.github/workflows/android-build.yml`
- Setup de JDK 17 (Temurin) + Node.js 20
- Geração dinâmica da pasta `/android` via `expo prebuild`
- Compilação do APK com `gradlew assembleRelease`
- Upload do `.apk` como artefato do Actions
- Criação automática de GitHub Release versionada por `run_number` (apenas em `push` na `release`)

## Gatilhos

| Evento | Comportamento |
|---|---|
| `pull_request` → `release` | Build completo para validação |
| `push` → `release` | Build + artefato + GitHub Release oficial |