### PR TITLE
feat: integração com Docker Hub e push automático da imagem

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker - Build
+name: Docker - Build e Push
 
 on:
   push:
@@ -21,11 +21,23 @@ jobs:
         run: |
           SHA=${GITHUB_SHA::7}
           echo "sha=$SHA" >> $GITHUB_OUTPUT
-          echo "SHA do commit: $SHA"
+
+      - name: Login no Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build da imagem Docker
         run: |
           docker build \
             --build-arg TMDB_API_KEY=${{ secrets.TMDB_API_KEY }} \
-            -t tmdb-app:${{ steps.vars.outputs.sha }} \
+            -t ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:${{ steps.vars.outputs.sha }} \
+            -t ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest \
             .
+
+      - name: Push da imagem para o Docker Hub
+        if: github.event_name == 'push'
+        run: |
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:${{ steps.vars.outputs.sha }}
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest


### PR DESCRIPTION
Atualizado o workflow docker.yml pra completar o bônus 3. Adicionado autenticação no Docker Hub via docker/login-action usando os secrets DOCKERHUB_USERNAME e DOCKERHUB_TOKEN. A imagem agora é tagueada com o SHA do commit e também com latest. O push para o Docker Hub acontece apenas em push direto na release, não em PRs.

Fixes #7