### PR TITLE
ci: substituindo comandos manuais docker por build-push-action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,16 +28,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build da imagem Docker
-        run: |
-          docker build \
-            --build-arg TMDB_API_KEY=${{ secrets.TMDB_API_KEY }} \
-            -t ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:${{ steps.vars.outputs.sha }} \
-            -t ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest \
-            .
+      - name: Configurar Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push da imagem para o Docker Hub
-        if: github.event_name == 'push'
-        run: |
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:${{ steps.vars.outputs.sha }}
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest
+      - name: Build e Push da imagem Docker
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:${{ steps.vars.outputs.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest
+          build-args: |
+            TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}


### PR DESCRIPTION
Substituindo os steps manuais de build e push por docker/build-push-action@v6, unificando as duas etapas em um único step declarativo. Adicionando docker/setup-buildx-action@v3 como pré-requisito da action.

Fixes #8