### PR TITLE
ci: adicionando suporte a múltiplas arquiteturas com buildx

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,5 +39,6 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:${{ steps.vars.outputs.sha }}
             ${{ secrets.DOCKERHUB_USERNAME }}/tmdb-app:latest
+          platforms: linux/amd64,linux/arm64
           build-args: |
             TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}


### PR DESCRIPTION
Adicionando o parâmetro platforms ao build-push-action para compilar a imagem simultaneamente para linux/amd64 e linux/arm64. O setup-buildx-action já estava configurado pelo bônus 4, então só foi necessária essa linha.

Fixes #18